### PR TITLE
Make build work with a more modern JDK.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,9 @@
   <version>1.3-xni06-20200415</version>
   <name>jcoord</name>
   <url>http://maven.apache.org</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -15,4 +18,16 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Set default encoding (remove a warning).